### PR TITLE
Add photon helper

### DIFF
--- a/EgammaAnalysis/interface/PhotonIDHelper.h
+++ b/EgammaAnalysis/interface/PhotonIDHelper.h
@@ -1,0 +1,95 @@
+//--------------------------------------------------------------------------------------------------
+//
+// EGammaID Helper
+//
+// Helper Class to compute photon ID observables
+//
+// Authors: F. Beaudette,A. Lobanov
+//--------------------------------------------------------------------------------------------------
+
+#ifndef PhotonIDHelper_H
+#define PhotonIDHelper_H
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+
+#include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
+#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
+#include "DataFormats/HGCRecHit/interface/HGCRecHitCollections.h"
+
+#include "EgammaTools/EgammaAnalysis/interface/EgammaPCAHelper.h"
+#include "EgammaTools/EgammaAnalysis/interface/LongDeps.h"
+
+#include <vector>
+
+class PhotonIDHelper {
+public:
+    PhotonIDHelper(){;}
+    PhotonIDHelper(const edm::ParameterSet &, edm::ConsumesCollector && iC);
+    ~PhotonIDHelper(){;}
+    // Use either eventInit if you are not using the HGCAL ntupler or setHitMap and setRecHitTools
+    // to be run once per event
+    void eventInit(const edm::Event& iEvent,const edm::EventSetup &iSetup);
+
+    //  use these two setters from the HGCAL ntupler before doing anaything else
+    inline void setHitMap( std::map<DetId,const HGCRecHit *> * hitMap) {
+            pcaHelper_.setHitMap(hitMap);
+    }
+    void setRecHitTools(const hgcal::RecHitTools * recHitTools);
+
+    void computeHGCAL(const reco::Photon & thePhoton, float radius);
+
+    inline double photonClusterEnergy() const { return thePhoton_->superCluster()->seed()->energy();}
+
+    inline double photonSCEnergy() const {return thePhoton_->superCluster()->energy();}
+
+    inline double sigmaUU() const {  return pcaHelper_.sigmaUU();}
+    inline double sigmaVV() const {  return pcaHelper_.sigmaVV();}
+    inline double sigmaEE() const {  return pcaHelper_.sigmaEE();}
+    inline double sigmaPP() const {  return pcaHelper_.sigmaPP();}
+    inline TVectorD eigenValues () const {return pcaHelper_.eigenValues();}
+    inline TVectorD sigmas() const {return pcaHelper_.sigmas();}
+
+
+    // longitudinal energy deposits and energy per subdetector as well as layers crossed
+    LongDeps energyPerLayer(float radius, bool withHalo=true) {
+        return pcaHelper_.energyPerLayer(radius,withHalo);
+    }
+    /*
+    inline  math::XYZVectorF trackMomentumAtEleClus() const {return thePhoton_->trackMomentumAtEleClus();}
+    inline float deltaEtaEleClusterTrackAtCalo() const {return thePhoton_->deltaEtaEleClusterTrackAtCalo();}
+    inline float deltaPhiEleClusterTrackAtCalo() const {return thePhoton_->deltaPhiEleClusterTrackAtCalo();}
+    inline float eEleClusterOverPout() const {return thePhoton_->eEleClusterOverPout();}
+    */
+
+    const math::XYZPoint  & barycenter() const {return pcaHelper_.barycenter();}
+    const math::XYZVector & axis() const {return pcaHelper_.axis();}
+    void printHits(float radius) const { pcaHelper_.printHits(radius); }
+
+    float clusterDepthCompatibility(const LongDeps & ld, float & measDepth, float & expDepth, float & expSigma)
+        { return pcaHelper_.clusterDepthCompatibility(ld,measDepth,expDepth,expSigma);}
+
+    /// for debugging purposes, if you have to use it, it means that an interface method is missing
+    EGammaPCAHelper * pcaHelper () {return &pcaHelper_;}
+
+private:
+    const reco::Photon * thePhoton_;
+    edm::InputTag  eeRecHitInputTag_;
+    edm::InputTag  fhRecHitInputTag_;
+    edm::InputTag  bhRecHitInputTag_;
+
+    std::vector<double> dEdXWeights_;
+    EGammaPCAHelper pcaHelper_;
+    edm::EDGetTokenT<HGCRecHitCollection> recHitsEE_;
+    edm::EDGetTokenT<HGCRecHitCollection> recHitsFH_;
+    edm::EDGetTokenT<HGCRecHitCollection> recHitsBH_;
+    hgcal::RecHitTools recHitTools_;
+    bool debug_;
+};
+
+#endif

--- a/EgammaAnalysis/interface/PhotonIDHelper.h
+++ b/EgammaAnalysis/interface/PhotonIDHelper.h
@@ -18,7 +18,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 
-#include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
+#include "DataFormats/EgammaCandidates/interface/Photon.h"
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 #include "DataFormats/HGCRecHit/interface/HGCRecHitCollections.h"
 

--- a/EgammaAnalysis/src/PhotonIDHelper.cc
+++ b/EgammaAnalysis/src/PhotonIDHelper.cc
@@ -1,0 +1,55 @@
+#include "EgammaTools/EgammaAnalysis/interface/PhotonIDHelper.h"
+
+#include <iostream>
+
+PhotonIDHelper::PhotonIDHelper(const edm::ParameterSet  & iConfig,edm::ConsumesCollector && iC):
+        eeRecHitInputTag_(iConfig.getParameter<edm::InputTag> ("EERecHits") ),
+        fhRecHitInputTag_(iConfig.getParameter<edm::InputTag> ("FHRecHits") ),
+        bhRecHitInputTag_(iConfig.getParameter<edm::InputTag> ("BHRecHits") ),
+        dEdXWeights_(iConfig.getParameter<std::vector<double> >("dEdXWeights")){
+    recHitsEE_ = iC.consumes<HGCRecHitCollection>(eeRecHitInputTag_);
+    recHitsFH_ = iC.consumes<HGCRecHitCollection>(fhRecHitInputTag_);
+    recHitsBH_ = iC.consumes<HGCRecHitCollection>(bhRecHitInputTag_);
+    pcaHelper_.setdEdXWeights(dEdXWeights_);
+    debug_ = false;
+}
+
+void PhotonIDHelper::eventInit(const edm::Event& iEvent,const edm::EventSetup &iSetup) {
+    edm::Handle<HGCRecHitCollection> recHitHandleEE;
+    iEvent.getByToken(recHitsEE_, recHitHandleEE);
+    edm::Handle<HGCRecHitCollection> recHitHandleFH;
+    iEvent.getByToken(recHitsFH_, recHitHandleFH);
+    edm::Handle<HGCRecHitCollection> recHitHandleBH;
+    iEvent.getByToken(recHitsBH_, recHitHandleBH);
+
+    pcaHelper_.fillHitMap(*recHitHandleEE,*recHitHandleFH,*recHitHandleBH);
+    recHitTools_.getEventSetup(iSetup);
+    pcaHelper_.setRecHitTools(&recHitTools_);
+}
+
+void PhotonIDHelper::setRecHitTools(const hgcal::RecHitTools * recHitTools){
+    pcaHelper_.setRecHitTools(recHitTools);
+}
+
+void PhotonIDHelper::computeHGCAL(const reco::Photon & thePhoton, float radius) {
+    thePhoton_ = &thePhoton;
+    if (thePhoton.isEB()) {
+        if (debug_) std::cout << "The photon is in the barrel" <<std::endl;
+        pcaHelper_.clear();
+        return;
+    }
+
+    pcaHelper_.storeRecHits(*thePhoton.superCluster()->seed());
+    if (debug_)
+        std::cout << " Stored the hits belonging to the photon superCluster seed " << std::endl;
+
+    // initial computation, no radius cut, but halo hits not taken
+    if (debug_)
+        std::cout << " Calling PCA initial computation" << std::endl;
+    pcaHelper_.pcaInitialComputation();
+    // first computation within cylinder, halo hits included
+    pcaHelper_.computePCA(radius);
+    // second computation within cylinder, halo hits included
+    pcaHelper_.computePCA(radius);
+    pcaHelper_.computeShowerWidth(radius);
+}

--- a/EgammaAnalysis/test/PhotonIDTest.cc
+++ b/EgammaAnalysis/test/PhotonIDTest.cc
@@ -1,0 +1,89 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "EgammaTools/EgammaAnalysis/interface/PhotonIDHelper.h"
+#include "EgammaTools/EgammaAnalysis/interface/LongDeps.h"
+
+#include <iostream>
+#include <iomanip>
+
+class PhotonIdTest : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::SharedResources> {
+
+public:
+
+    PhotonIdTest();
+    explicit PhotonIdTest(const edm::ParameterSet &);
+    ~PhotonIdTest();
+
+    virtual void beginRun(edm::Run const &iEvent, edm::EventSetup const &) override;
+    virtual void endRun(edm::Run const &iEvent, edm::EventSetup const &) override;
+
+private:
+     virtual void analyze(const edm::Event &, const edm::EventSetup &) override;
+
+private:
+     PhotonIDHelper * pIDHelper_;
+     edm::InputTag photonTag_;
+     edm::EDGetTokenT<std::vector<reco::Photon>> photons_;
+};
+
+PhotonIdTest::PhotonIdTest(){;}
+
+PhotonIdTest::~PhotonIdTest(){;}
+
+PhotonIdTest::PhotonIdTest(const edm::ParameterSet &iConfig)
+{
+    pIDHelper_ = new PhotonIDHelper(iConfig ,consumesCollector());
+    photonTag_ = iConfig.getParameter<edm::InputTag>("Photons");
+    photons_ = consumes<std::vector<reco::Photon>>(photonTag_);
+}
+
+void PhotonIdTest::beginRun(edm::Run const &iEvent, edm::EventSetup const &) {;}
+
+void PhotonIdTest::endRun(edm::Run const &iEvent, edm::EventSetup const &) {;}
+
+void PhotonIdTest::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
+    pIDHelper_->eventInit(iEvent,iSetup);
+
+    edm::Handle<std::vector<reco::Photon>> phoHandle;
+    iEvent.getByToken(photons_, phoHandle);
+    for (auto photon : *phoHandle) {
+        std::cout << " Photon eta pt" << photon.eta() << " " << photon.pt() << std::endl;
+        if (photon.isEB()) continue;
+        pIDHelper_->computeHGCAL(photon,3.);
+        std::cout << "sigmaUU " << pIDHelper_->sigmaUU() << std::endl;
+        std::cout << "sigmaVV " << pIDHelper_->sigmaVV() << std::endl;
+        std::cout << "sigmaEE " << pIDHelper_->sigmaEE() << std::endl;
+        std::cout << "sigmaPP " << pIDHelper_->sigmaPP() << std::endl;
+
+        LongDeps ld(pIDHelper_->energyPerLayer(3.,true));
+        std::cout << "Nlayers " << ld.nLayers() << std::endl;
+
+	//    std::cout << "GSF pt " << std::sqrt(photon.trackMomentumAtVtx().perp2()) << " " << photon.photonCluster()->energy() << std::endl;
+    //   std::cout << photon.photonCluster()->size() << " " << photon.photonCluster()->hitsAndFractions().size() << std::endl;
+    //   pIDHelper_->printHits(3.);
+
+        std::cout << "First layer " << ld.firstLayer() << std::endl;
+        std::cout << "Last layer " << ld.lastLayer() << std::endl;
+
+        for (unsigned l=1;l<=52;++l) {
+            std::cout << std::fixed << std::setw( 5 ) << std::setprecision( 2 ) << ld.energyPerLayer()[l] << " " ;
+        }
+        std::cout << std::endl;
+        std::cout << " Energy EE " << ld.energyEE() << " EnergyFH " << ld.energyFH() << " EnergyBH " << ld.energyBH() <<std::endl;
+
+        float measuredDepth, expectedDepth, expectedSigma;
+        float depthCompatibility = pIDHelper_->clusterDepthCompatibility(ld,measuredDepth,expectedDepth, expectedSigma);
+        std::cout << " Depth " << measuredDepth << " Exp. Depth " << expectedDepth << " ";
+        std::cout << "Exp. Sigma " << expectedSigma <<  " Depth compatibility " <<depthCompatibility << std::endl;
+    }
+
+}
+
+// define this as a plug-in
+DEFINE_FWK_MODULE(PhotonIdTest);

--- a/EgammaAnalysis/test/photonIDPrinter.py
+++ b/EgammaAnalysis/test/photonIDPrinter.py
@@ -1,0 +1,35 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PhotonID")
+
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('Configuration.Geometry.GeometryExtended2023D17Reco_cff')
+from RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi import dEdX_weights as dEdX
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
+
+process.source = cms.Source("PoolSource",
+    # replace 'myfile.root' with the source file you want to use
+    fileNames = cms.untracked.vstring(
+        '/store/relval/CMSSW_9_3_2/RelValSingleElectronPt15Eta1p7_2p7/GEN-SIM-RECO/93X_upgrade2023_realistic_v2_2023D17noPU-v1/10000/D0226E59-00A7-E711-AA65-0CC47A78A426.root',
+        '/store/relval/CMSSW_9_3_2/RelValSingleElectronPt15Eta1p7_2p7/GEN-SIM-RECO/93X_upgrade2023_realistic_v2_2023D17noPU-v1/10000/FE5CADD8-01A7-E711-B465-0CC47A7C35A4.root',
+        '/store/relval/CMSSW_9_3_2/RelValSingleElectronPt15Eta1p7_2p7/GEN-SIM-RECO/93X_upgrade2023_realistic_v2_2023D17noPU-v1/10000/E8E9A7E8-02A7-E711-A8FA-0CC47A4C8E46.root',
+        '/store/relval/CMSSW_9_3_2/RelValSingleElectronPt15Eta1p7_2p7/GEN-SIM-RECO/93X_upgrade2023_realistic_v2_2023D17noPU-v1/10000/9E833A7E-08A7-E711-A414-0025905B859E.root',
+        '/store/relval/CMSSW_9_3_2/RelValSingleElectronPt15Eta1p7_2p7/GEN-SIM-RECO/93X_upgrade2023_realistic_v2_2023D17noPU-v1/10000/E4C8A780-08A7-E711-AEF4-0025905A6090.root'
+    ),
+
+#    eventsToProcess = cms.untracked.VEventRange('1:7498-1:7498'),
+    duplicateCheckMode = cms.untracked.string("noDuplicateCheck")
+)
+
+
+process.photonID = cms.EDAnalyzer('PhotonIdTest',
+                                    EERecHits = cms.InputTag('HGCalRecHit:HGCEERecHits'),
+                                    FHRecHits = cms.InputTag('HGCalRecHit:HGCHEFRecHits'),
+                                    BHRecHits = cms.InputTag('HGCalRecHit:HGCHEBRecHits'),
+                                    Photons = cms.InputTag('photonsFromMultiCl'),
+                                    dEdXWeights = dEdX
+
+)
+
+process.p = cms.Path(process.photonID)

--- a/EgammaAnalysis/test/photonIDPrinter.py
+++ b/EgammaAnalysis/test/photonIDPrinter.py
@@ -11,11 +11,11 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
 process.source = cms.Source("PoolSource",
     # replace 'myfile.root' with the source file you want to use
     fileNames = cms.untracked.vstring(
-        '/store/relval/CMSSW_9_3_2/RelValSingleElectronPt15Eta1p7_2p7/GEN-SIM-RECO/93X_upgrade2023_realistic_v2_2023D17noPU-v1/10000/D0226E59-00A7-E711-AA65-0CC47A78A426.root',
-        '/store/relval/CMSSW_9_3_2/RelValSingleElectronPt15Eta1p7_2p7/GEN-SIM-RECO/93X_upgrade2023_realistic_v2_2023D17noPU-v1/10000/FE5CADD8-01A7-E711-B465-0CC47A7C35A4.root',
-        '/store/relval/CMSSW_9_3_2/RelValSingleElectronPt15Eta1p7_2p7/GEN-SIM-RECO/93X_upgrade2023_realistic_v2_2023D17noPU-v1/10000/E8E9A7E8-02A7-E711-A8FA-0CC47A4C8E46.root',
-        '/store/relval/CMSSW_9_3_2/RelValSingleElectronPt15Eta1p7_2p7/GEN-SIM-RECO/93X_upgrade2023_realistic_v2_2023D17noPU-v1/10000/9E833A7E-08A7-E711-A414-0025905B859E.root',
-        '/store/relval/CMSSW_9_3_2/RelValSingleElectronPt15Eta1p7_2p7/GEN-SIM-RECO/93X_upgrade2023_realistic_v2_2023D17noPU-v1/10000/E4C8A780-08A7-E711-AEF4-0025905A6090.root'
+        '/store/relval/CMSSW_9_3_2/RelValSingleGammaPt25Eta1p7_2p7/GEN-SIM-RECO/93X_upgrade2023_realistic_v2_2023D17noPU-v1/10000/321D865F-DBA6-E711-9859-0CC47A4D768C.root',
+        '/store/relval/CMSSW_9_3_2/RelValSingleGammaPt25Eta1p7_2p7/GEN-SIM-RECO/93X_upgrade2023_realistic_v2_2023D17noPU-v1/10000/84704C20-D7A6-E711-A677-0025905A608A.root',
+        '/store/relval/CMSSW_9_3_2/RelValSingleGammaPt25Eta1p7_2p7/GEN-SIM-RECO/93X_upgrade2023_realistic_v2_2023D17noPU-v1/10000/B012B757-D5A6-E711-B53F-0025905B85FC.root',
+        '/store/relval/CMSSW_9_3_2/RelValSingleGammaPt25Eta1p7_2p7/GEN-SIM-RECO/93X_upgrade2023_realistic_v2_2023D17noPU-v1/10000/B61D085E-DBA6-E711-9DC2-0CC47A78A418.root',
+        '/store/relval/CMSSW_9_3_2/RelValSingleGammaPt25Eta1p7_2p7/GEN-SIM-RECO/93X_upgrade2023_realistic_v2_2023D17noPU-v1/10000/D2F3E811-D7A6-E711-8092-0CC47A7C3432.root'
     ),
 
 #    eventsToProcess = cms.untracked.VEventRange('1:7498-1:7498'),


### PR DESCRIPTION
Create PhotonIDhelper based on the ElectronIDhelper, removing electron track specific part.
Based on https://github.com/CMS-HGCAL/EgammaTools/pull/3, but replaces it for the photon helper part. This separation will allow for a safer and cleaner use of the helpers.

For most variables this should be fine, except that here also only the seed cluster is used to compute the variables (as for electrons), and not the full supercluster. The longitudinal profile prediction should be adapted to photon showers as well.

@nsmith- , could you modify your ValueMap to use this class? And create a new PR with the ValueMap only. Maybe also interesting for @jkiesele.