### PR TITLE
Change return type for PCA/ID helper

### DIFF
--- a/EgammaAnalysis/interface/EgammaPCAHelper.h
+++ b/EgammaAnalysis/interface/EgammaPCAHelper.h
@@ -59,7 +59,7 @@ public:
         computePCA(-1.,false);
     }
 
-    void computePCA(float radius, bool withHalo=true);
+    bool computePCA(float radius, bool withHalo=true);
     const math::XYZPoint  & barycenter() const {return barycenter_;}
     const math::XYZVector & axis() const {return axis_;}
 

--- a/EgammaAnalysis/interface/ElectronIDHelper.h
+++ b/EgammaAnalysis/interface/ElectronIDHelper.h
@@ -43,7 +43,7 @@ public:
     }
     void setRecHitTools(const hgcal::RecHitTools * recHitTools);
 
-    void computeHGCAL(const reco::GsfElectron & theElectron, float radius);
+    int computeHGCAL(const reco::GsfElectron & theElectron, float radius);
 
     inline double electronClusterEnergy() const { return theElectron_->electronCluster()->energy();}
 

--- a/EgammaAnalysis/interface/PhotonIDHelper.h
+++ b/EgammaAnalysis/interface/PhotonIDHelper.h
@@ -43,7 +43,7 @@ public:
     }
     void setRecHitTools(const hgcal::RecHitTools * recHitTools);
 
-    void computeHGCAL(const reco::Photon & thePhoton, float radius);
+    int computeHGCAL(const reco::Photon & thePhoton, float radius);
 
     inline double photonClusterEnergy() const { return thePhoton_->superCluster()->seed()->energy();}
 

--- a/EgammaAnalysis/src/EgammaPCAHelper.cc
+++ b/EgammaAnalysis/src/EgammaPCAHelper.cc
@@ -137,7 +137,7 @@ void EGammaPCAHelper::storeRecHits(const std::vector<std::pair<DetId, float>> &h
     }
 }
 
-void EGammaPCAHelper::computePCA(float radius , bool withHalo) {
+bool EGammaPCAHelper::computePCA(float radius , bool withHalo) {
     // very important - to reset
     pca_.reset(new TPrincipal(3, "D"));
     bool initialCalculation = radius < 0;
@@ -187,7 +187,7 @@ void EGammaPCAHelper::computePCA(float radius , bool withHalo) {
         std::cout << " Nlayers " << layers.size() << std::endl;
     if (layers.size() < 3) {
         pcaIteration_ = -1;
-        return;
+        return 0;
     }
     pca_->MakePrincipals();
     ++pcaIteration_;
@@ -201,6 +201,8 @@ void EGammaPCAHelper::computePCA(float radius , bool withHalo) {
     if (axis_.z() * barycenter_.z() < 0.0) {
         axis_ = math::XYZVector(-eigens(0, 0), -eigens(1, 0), -eigens(2, 0));
     }
+
+    return 1;
 }
 
  void EGammaPCAHelper::computeShowerWidth(float radius, bool withHalo){

--- a/EgammaAnalysis/src/ElectronIDHelper.cc
+++ b/EgammaAnalysis/src/ElectronIDHelper.cc
@@ -57,8 +57,11 @@ int ElectronIDHelper::computeHGCAL(const reco::GsfElectron & theElectron, float 
     // first computation within cylinder, halo hits included
     pcaHelper_.computePCA(radius);
     // second computation within cylinder, halo hits included
-    pcaHelper_.computePCA(radius);
+    if(!pcaHelper_.computePCA(radius)) return 0;
+
     pcaHelper_.computeShowerWidth(radius);
+
+    // isolation
     isoHelper_.produceHGCalIso(theElectron.electronCluster());
 
     return 1;

--- a/EgammaAnalysis/src/ElectronIDHelper.cc
+++ b/EgammaAnalysis/src/ElectronIDHelper.cc
@@ -38,12 +38,12 @@ void ElectronIDHelper::setRecHitTools(const hgcal::RecHitTools * recHitTools){
     pcaHelper_.setRecHitTools(recHitTools);
 }
 
-void ElectronIDHelper::computeHGCAL(const reco::GsfElectron & theElectron, float radius) {
+int ElectronIDHelper::computeHGCAL(const reco::GsfElectron & theElectron, float radius) {
     theElectron_ = &theElectron;
     if (theElectron.isEB()) {
         if (debug_) std::cout << "The electron is in the barrel" <<std::endl;
         pcaHelper_.clear();
-        return;
+        return 0;
     }
 
     pcaHelper_.storeRecHits(*theElectron.electronCluster());
@@ -60,4 +60,6 @@ void ElectronIDHelper::computeHGCAL(const reco::GsfElectron & theElectron, float
     pcaHelper_.computePCA(radius);
     pcaHelper_.computeShowerWidth(radius);
     isoHelper_.produceHGCalIso(theElectron.electronCluster());
+
+    return 1;
 }

--- a/EgammaAnalysis/src/PhotonIDHelper.cc
+++ b/EgammaAnalysis/src/PhotonIDHelper.cc
@@ -58,7 +58,8 @@ int PhotonIDHelper::computeHGCAL(const reco::Photon & thePhoton, float radius) {
     // first computation within cylinder, halo hits included
     pcaHelper_.computePCA(radius);
     // second computation within cylinder, halo hits included
-    pcaHelper_.computePCA(radius);
+    if(!pcaHelper_.computePCA(radius)) return 0;
+
     pcaHelper_.computeShowerWidth(radius);
 
     // isolation

--- a/EgammaAnalysis/src/PhotonIDHelper.cc
+++ b/EgammaAnalysis/src/PhotonIDHelper.cc
@@ -39,12 +39,12 @@ void PhotonIDHelper::setRecHitTools(const hgcal::RecHitTools * recHitTools){
     isoHelper_.setRecHitTools(recHitTools);
 }
 
-void PhotonIDHelper::computeHGCAL(const reco::Photon & thePhoton, float radius) {
+int PhotonIDHelper::computeHGCAL(const reco::Photon & thePhoton, float radius) {
     thePhoton_ = &thePhoton;
     if (thePhoton.isEB()) {
         if (debug_) std::cout << "The photon is in the barrel" <<std::endl;
         pcaHelper_.clear();
-        return;
+        return 0;
     }
 
     pcaHelper_.storeRecHits(*thePhoton.superCluster()->seed());
@@ -63,4 +63,6 @@ void PhotonIDHelper::computeHGCAL(const reco::Photon & thePhoton, float radius) 
 
     // isolation
     isoHelper_.produceHGCalIso(thePhoton.superCluster()->seed());
+
+    return 1;
 }


### PR DESCRIPTION
Return 0 for computeHGCAL in case the PCA fails (i.e. cluster fails requirements).